### PR TITLE
Add a simple bash script to create a TwinCAT BSD Virtual Machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,37 @@ Usage
 PS C:\YOUR_FOLDER\.\Create-TcBsdVM.ps1 MyLovelyTcBSD TCBSD-x64-12-40411.iso
 ~~~
 
+## Using the bash script
+
+The included bash script ``create_tc_bsd_vm.sh`` will generate a VM with the
+following specifications:
+
+* 8GB OS primary OS (SATA) disk image
+* 1GB of RAM
+* One network adapter (NAT -> may require reconfiguration; see below)
+* The bootable TwinCAT BSD installation media connected as the second SATA drive
+    * This will boot until the installation is complete. It can be removed
+      after installation is done, but it will not interfere with TC/BSD
+      from booting post-installation even if it remains.
+
+In order to use it, you must:
+
+* Download TwinCAT BSD image from Beckhoff first. Place it in the same
+  directory as the script.
+* Run ``./create_tc_bsd_vm.sh your_plc_name_here [/path/to/tcbsd.iso]``
+
+Notes:
+
+* If you only have a single TCBSD ISO in the same directory, the script will
+  find it and use it automatically. In that case, you will only need to specify
+  the PLC name.
+* VBoxManage is expected to be on the ``PATH`` prior to running the script.
+* After creating a VM, a file browser will be opened to the path where the
+  generated image is.
+* The script will register the VM with VirtualBox.  If a VM already is
+  registered with the same name, it will give you the option of unregistering
+  the old one.
+
 # Setting up the network interface
 
 If VMs network defaults to `NAT`, you may not be able to connect to the PLC. Therefore you should set the virtual network either to `Host-Only Adapter` if you are working with the PLC only from the host computer; or `Bridged Adpater` to set up a physical connection to the outside network.

--- a/create_tc_bsd_vm.sh
+++ b/create_tc_bsd_vm.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+#
+#  by @klauer, loosely based on https://github.com/PTKu/TwinCAT-BSD-VM-creator
 
 set -e
 
@@ -32,13 +34,12 @@ echo "* Disk name: ${VM_NAME}"
 
 if [ ! -f "$TCBSD_ISO_IMAGE" ]; then
   die "
-* TcBsd ISO image not found. Download it here: 
+* TcBsd ISO image not found. Download it here:
   -> https://www.beckhoff.com/en-en/products/ipc/software-and-tools/operating-systems/c9900-s60x-cxxxxx-0185.html
-EOF
 "
 fi
 
-if ! command -v VBoxManage 2>/dev/null; then
+if ! command -v VBoxManage &>/dev/null; then
   die "VirtualBox installation not found."
 fi
 
@@ -57,11 +58,31 @@ vbox_manage() {
   echo ""
 }
 
+show_vm_info() {
+  VBoxManage showvminfo "$1"
+}
+
 set +e
 
 if [ ! -f "$TCBSD_VDI_IMAGE" ]; then
   echo "* Converting ISO to TcBSD VirtualBox-specific VDI"
   vbox_manage convertfromraw --format VDI "$TCBSD_ISO_IMAGE" "$TCBSD_VDI_IMAGE" 2>&1
+fi
+
+if show_vm_info "$VM_NAME" &> /dev/null; then
+  echo "VBoxManage reports that the VM ${VM_NAME} already exists."
+  read -rp "Delete it? [yN]" yn
+
+  if [[ "$yn" != "y" ]]; then
+    echo "VM already exists; cannot continue" >/dev/stderr
+    exit 1
+  fi
+
+  echo "Unregistering ${VM_NAME} from VirtualBox and moving files to a backup directory."
+  set -x
+  vbox_manage unregistervm "$VM_NAME"
+  mv "$VM_NAME" "${VM_NAME}.old.$(date +%s)"
+  set +x
 fi
 
 echo "* Creating the VM"
@@ -73,13 +94,13 @@ vbox_manage modifyvm "$VM_NAME" --memory 1024 --vram 128 --acpi on --hpet on --g
 echo "* Setting VM storage settings"
 vbox_manage storagectl "$VM_NAME" --name SATA --add sata --controller IntelAhci --hostiocache on --bootable on
 
-echo "* Attaching to installation HDD to Sata Port 1"
+echo "* Attaching to installation HDD to SATA Port 1"
 vbox_manage storageattach "$VM_NAME" --storagectl "SATA" --device 0 --port 1 --type hdd --medium "$TCBSD_VDI_IMAGE"
 
-echo "* Creating empty HDD"
-vbox_manage createmedium --filename "$VM_HDD" --size 4096 --format VHD 2>&1
+echo "* Creating an empty 8GB disk image for the TwinCAT BSD installation"
+vbox_manage createmedium --filename "$VM_HDD" --size 8192 --format VHD 2>&1
 
-echo "* Attaching created HDD to Sata Port 0 where we will install TwinCAT BSD"
+echo "* Attaching the empty disk image to SATA Port 0"
 vbox_manage storageattach "$VM_NAME" --storagectl "SATA" --device 0 --port 0 --type hdd --medium "$VM_HDD"
 
 if command -v xdg-open &>/dev/null; then

--- a/create_tc_bsd_vm.sh
+++ b/create_tc_bsd_vm.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -e
+
+usage () {
+  echo "Usage: $0 vm_name [tcbsd_iso_image]" >&2
+  exit 0
+}
+
+die () {
+  echo "$@" >&2
+  exit 1
+}
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+VM_NAME=$1
+TCBSD_ISO_IMAGE=$2
+VM_HDD="$PWD/$VM_NAME/$1.vhd"
+
+if [[ $# -lt 1 || $# -gt 2 || -z "$VM_NAME" ]]; then
+  usage
+fi
+
+if [ -z "$TCBSD_ISO_IMAGE" ]; then
+  # shellcheck disable=SC2012
+  TCBSD_ISO_IMAGE=$(ls "${SCRIPT_DIR}/TCBSD"*.iso | head -n 1)
+fi
+
+echo "* VM name: ${VM_NAME}"
+echo "* TcBSD ISO: ${TCBSD_ISO_IMAGE}"
+echo "* Disk name: ${VM_NAME}"
+
+if [ ! -f "$TCBSD_ISO_IMAGE" ]; then
+  die "
+* TcBsd ISO image not found. Download it here: 
+  -> https://www.beckhoff.com/en-en/products/ipc/software-and-tools/operating-systems/c9900-s60x-cxxxxx-0185.html
+EOF
+"
+fi
+
+if ! command -v VBoxManage 2>/dev/null; then
+  die "VirtualBox installation not found."
+fi
+
+TCBSD_VDI_IMAGE="$SCRIPT_DIR/$(basename "${TCBSD_ISO_IMAGE%.*}").vdi"
+
+echo "* TcBSD VirtualBox-specific VDI: ${TCBSD_VDI_IMAGE}"
+
+vbox_manage() {
+  echo "Running: VBoxManage $*"
+  VBoxManage "$@"
+  EXIT_CODE=$?
+  if [ $EXIT_CODE -gt 0 ]; then
+    echo "VBoxManage reported exit code $EXIT_CODE; exiting early."
+    exit "$EXIT_CODE"
+  fi
+  echo ""
+}
+
+set +e
+
+if [ ! -f "$TCBSD_VDI_IMAGE" ]; then
+  echo "* Converting ISO to TcBSD VirtualBox-specific VDI"
+  vbox_manage convertfromraw --format VDI "$TCBSD_ISO_IMAGE" "$TCBSD_VDI_IMAGE" 2>&1
+fi
+
+echo "* Creating the VM"
+vbox_manage createvm --name "$VM_NAME" --basefolder "$PWD" --ostype FreeBSD_64 --register
+
+echo "* Setting VM basic settings"
+vbox_manage modifyvm "$VM_NAME" --memory 1024 --vram 128 --acpi on --hpet on --graphicscontroller vmsvga --firmware efi64
+
+echo "* Setting VM storage settings"
+vbox_manage storagectl "$VM_NAME" --name SATA --add sata --controller IntelAhci --hostiocache on --bootable on
+
+echo "* Attaching to installation HDD to Sata Port 1"
+vbox_manage storageattach "$VM_NAME" --storagectl "SATA" --device 0 --port 1 --type hdd --medium "$TCBSD_VDI_IMAGE"
+
+echo "* Creating empty HDD"
+vbox_manage createmedium --filename "$VM_HDD" --size 4096 --format VHD 2>&1
+
+echo "* Attaching created HDD to Sata Port 0 where we will install TwinCAT BSD"
+vbox_manage storageattach "$VM_NAME" --storagectl "SATA" --device 0 --port 0 --type hdd --medium "$VM_HDD"
+
+if command -v xdg-open &>/dev/null; then
+  OPEN="xdg-open"
+elif command -v open &>/dev/null; then
+  OPEN="open"
+elif command -v start.exe &>/dev/null; then
+  OPEN="start.exe"
+else
+  echo "Created VM but unable to figure out how to show it to you.  Look in $PWD/$VM_NAME"
+  ls "$PWD/$VM_NAME"
+  exit 0
+fi
+
+"$OPEN" "$PWD/$VM_NAME"


### PR DESCRIPTION
## Context

This script allows you to create TcBSD VMs on MacOS/Linux systems.

It's very similar in functionality to the PowerShell/batch files that already exist in the repository.

## Documentation

Usage:

```bash
$ bash create_tc_bsd_vm.sh virtual-machine-name-here
or with the specific ISO name:
$ bash create_tc_bsd_vm.sh virtual-machine-name-here path-to-iso-image.iso
```

I didn't get a chance to modify the `README`, but if you're open to the contribution I can circle back to this.

## Testing

I've tested this locally with some [Ansible-based provisioning](https://github.com/pcdshub/twincat-bsd-ansible-testing/pull/1) I've been working on. So far, it seems to be working rather well.